### PR TITLE
VRCSDK導入済み環境で生成されたテクスチャが暗くなる問題を解消

### DIFF
--- a/Assets/AliceLaboratory/Editor/Utilities.cs
+++ b/Assets/AliceLaboratory/Editor/Utilities.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEditor;
 
 namespace AliceLaboratory.Editor {
     public class Utilities {
@@ -49,6 +50,19 @@ namespace AliceLaboratory.Editor {
             // ReadPixels()でレンダーターゲットからテクスチャ情報を生成する
             var texture = new Texture2D(target.width, target.height);
             texture.ReadPixels(new Rect(0, 0, target.width, target.height), 0, 0);
+            
+            // VRCSDK導入済みのプロジェクトでは色空間が変わっているので補正をかける
+            if (PlayerSettings.colorSpace == ColorSpace.Linear) {
+                // ガンマ補正
+                var color = texture.GetPixels();
+                for (int i = 0; i < color.Length; i++) {
+                    color[i].r = Mathf.LinearToGammaSpace(color[i].r);
+                    color[i].g = Mathf.LinearToGammaSpace(color[i].g);
+                    color[i].b = Mathf.LinearToGammaSpace(color[i].b);
+                }
+                texture.SetPixels(color);
+            }
+
             texture.Apply();
 
             RenderTexture.active = preRT;

--- a/Assets/Scenes/ExampleScene.unity
+++ b/Assets/Scenes/ExampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657868, g: 0.49641263, b: 0.57481706, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## VRCSDK導入済み環境で生成されたテクスチャが暗くなる問題を解消